### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/app/src/main/java/org/totschnig/sendwithftp/FtpTransfer.java
+++ b/app/src/main/java/org/totschnig/sendwithftp/FtpTransfer.java
@@ -50,12 +50,12 @@ import android.widget.Toast;
 
 
 public class FtpTransfer extends Activity {
-  ProgressDialog mProgressDialog;
+  private ProgressDialog mProgressDialog;
   private FtpAsyncTask task=null;
-  Uri target;
-  InputStream is;
-  String fileName;
-  int fileType = FTP.BINARY_FILE_TYPE;
+  private Uri target;
+  private InputStream is;
+  private String fileName;
+  private int fileType = FTP.BINARY_FILE_TYPE;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -222,8 +222,8 @@ public class FtpTransfer extends Activity {
       private String fileName;
       private InputStream is;
       private int fileType;
-      Result result;
-      ProgressDialog mProgressDialog;
+      private Result result;
+      private ProgressDialog mProgressDialog;
 
       public FtpAsyncTask(FtpTransfer activity,InputStream is,Uri target2, String fileName,int fileType) {
         attach(activity);

--- a/app/src/main/java/org/totschnig/sendwithftp/UriDataSource.java
+++ b/app/src/main/java/org/totschnig/sendwithftp/UriDataSource.java
@@ -32,7 +32,7 @@ public class UriDataSource {
   private String[] allColumns = { SQLiteHelper.COLUMN_ID,
       SQLiteHelper.COLUMN_URI };
   
-  Context context;
+  private Context context;
 
   public UriDataSource(Context context) {
     this.context = context;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat